### PR TITLE
✨ Add base `GithubService` Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env/
 *.sha256
 terraform.tfstate
 *.pyc
+.idea/

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -1,0 +1,6 @@
+from github import Github
+
+
+class GithubService:
+    def __init__(self, org_token: str) -> None:
+        self.client = Github(org_token)

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -1,6 +1,14 @@
+import logging
+
 from github import Github
 
 
 class GithubService:
-    def __init__(self, org_token: str) -> None:
+    def __init__(self, org_token: str, organisation_name: str) -> None:
         self.client = Github(org_token)
+        self.organisation_name = organisation_name
+
+    def get_outside_collaborators_login_names(self) -> list[str]:
+        logging.info("Getting Outside Collaborators Login Names")
+        outside_collaborators = self.client.get_organization(self.organisation_name).get_outside_collaborators()
+        return [outside_collaborator.get("login") for outside_collaborator in outside_collaborators]

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -10,5 +10,6 @@ class GithubService:
 
     def get_outside_collaborators_login_names(self) -> list[str]:
         logging.info("Getting Outside Collaborators Login Names")
-        outside_collaborators = self.client.get_organization(self.organisation_name).get_outside_collaborators() or []
+        outside_collaborators = self.client.get_organization(
+            self.organisation_name).get_outside_collaborators() or []
         return [outside_collaborator.get("login") for outside_collaborator in outside_collaborators]

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -10,5 +10,5 @@ class GithubService:
 
     def get_outside_collaborators_login_names(self) -> list[str]:
         logging.info("Getting Outside Collaborators Login Names")
-        outside_collaborators = self.client.get_organization(self.organisation_name).get_outside_collaborators()
+        outside_collaborators = self.client.get_organization(self.organisation_name).get_outside_collaborators() or []
         return [outside_collaborator.get("login") for outside_collaborator in outside_collaborators]

--- a/scripts/python/services/test_GithubService.py
+++ b/scripts/python/services/test_GithubService.py
@@ -3,44 +3,53 @@ from unittest.mock import call, MagicMock, patch
 
 from scripts.python.services.GithubService import GithubService
 
+ORGANISATION_NAME = "moj-analytical-services"
+
 
 class TestGithubService(unittest.TestCase):
+    mock_github = None
+
+    github_service = None
+
     def setUp(self):
-        print("setting up")
+        self.mock_github = MagicMock()
+        self.patcher = patch(target="github.Github.__new__", return_value=self.mock_github, autospec=True)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+        self.github_service = GithubService("", ORGANISATION_NAME)
 
     def tearDown(self):
-        print("tearing down")
+        self.patcher.stop()
 
     def test_innit_sets_up_class(self):
-        mock_github = MagicMock()
-        patcher = patch(target="github.Github.__new__", return_value=mock_github, autospec=True)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        github_service = GithubService("", "moj-analytical-services")
-
-        self.assertIs(mock_github, github_service.client)
-        self.assertEqual("moj-analytical-services", github_service.organisation_name)
-
-        patcher.stop()
+        self.assertIs(self.mock_github, self.github_service.client)
+        self.assertEqual(ORGANISATION_NAME, self.github_service.organisation_name)
 
     def test_get_outside_collaborators_login_names_returns_login_names(self):
-        mock_github = MagicMock()
-        patcher = patch(target="github.Github.__new__", return_value=mock_github, autospec=True)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        mock_github.get_organization().get_outside_collaborators.return_value = [{"login": "tom-smith"},
-                                                                                 {"login": "john.smith"}]
-
-        github_service = GithubService("", "moj-analytical-services")
-
-        response = github_service.get_outside_collaborators_login_names()
+        self.mock_github.get_organization().get_outside_collaborators.return_value = [{"login": "tom-smith"},
+                                                                                      {"login": "john.smith"}]
+        response = self.github_service.get_outside_collaborators_login_names()
         self.assertEqual(["tom-smith", "john.smith"], response)
-        mock_github.get_organization.assert_has_calls(
-            [call(), call('moj-analytical-services'), call().get_outside_collaborators()])
 
-        patcher.stop()
+    def test_get_outside_collaborators_login_names_calls_downstream_services(self):
+        self.mock_github.get_organization().get_outside_collaborators.return_value = []
+        self.github_service.get_outside_collaborators_login_names()
+        self.mock_github.get_organization.assert_has_calls(
+            [call(), call(ORGANISATION_NAME), call().get_outside_collaborators()])
+
+    def test_get_outside_collaborators_login_names_returns_empty_list_when_collaborators_returns_none(self):
+        self.mock_github.get_organization().get_outside_collaborators.return_value = None
+        response = self.github_service.get_outside_collaborators_login_names()
+        self.assertEqual([], response)
+
+    def test_get_outside_collaborators_login_names_returns_exception_when_collaborators_returns_exception(self):
+        self.mock_github.get_organization().get_outside_collaborators.side_effect = ConnectionError
+        self.assertRaises(ConnectionError, self.github_service.get_outside_collaborators_login_names)
+
+    def test_get_outside_collaborators_login_names_returns_exception_when_organization_returns_exception(self):
+        self.mock_github.get_organization.side_effect = ConnectionError
+        self.assertRaises(ConnectionError, self.github_service.get_outside_collaborators_login_names)
 
 
 if __name__ == "__main__":

--- a/scripts/python/services/test_GithubService.py
+++ b/scripts/python/services/test_GithubService.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from scripts.python.services.GithubService import GithubService
+
+
+class TestGithubService(unittest.TestCase):
+    mock_github = None
+
+    def setUp(self):
+        self.mock_github = Mock()
+        self.patcher = patch(target='github.Github.__new__', return_value=self.mock_github)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_innit_sets_up_class(self):
+        github_service = GithubService('')
+        self.assertIs(self.mock_github, github_service.client)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/python/services/test_GithubService.py
+++ b/scripts/python/services/test_GithubService.py
@@ -13,7 +13,8 @@ class TestGithubService(unittest.TestCase):
 
     def setUp(self):
         self.mock_github = MagicMock()
-        self.patcher = patch(target="github.Github.__new__", return_value=self.mock_github, autospec=True)
+        self.patcher = patch(target="github.Github.__new__",
+                             return_value=self.mock_github, autospec=True)
         self.patcher.start()
         self.addCleanup(self.patcher.stop)
 
@@ -24,7 +25,8 @@ class TestGithubService(unittest.TestCase):
 
     def test_innit_sets_up_class(self):
         self.assertIs(self.mock_github, self.github_service.client)
-        self.assertEqual(ORGANISATION_NAME, self.github_service.organisation_name)
+        self.assertEqual(ORGANISATION_NAME,
+                         self.github_service.organisation_name)
 
     def test_get_outside_collaborators_login_names_returns_login_names(self):
         self.mock_github.get_organization().get_outside_collaborators.return_value = [{"login": "tom-smith"},
@@ -44,12 +46,15 @@ class TestGithubService(unittest.TestCase):
         self.assertEqual([], response)
 
     def test_get_outside_collaborators_login_names_returns_exception_when_collaborators_returns_exception(self):
-        self.mock_github.get_organization().get_outside_collaborators.side_effect = ConnectionError
-        self.assertRaises(ConnectionError, self.github_service.get_outside_collaborators_login_names)
+        self.mock_github.get_organization(
+        ).get_outside_collaborators.side_effect = ConnectionError
+        self.assertRaises(
+            ConnectionError, self.github_service.get_outside_collaborators_login_names)
 
     def test_get_outside_collaborators_login_names_returns_exception_when_organization_returns_exception(self):
         self.mock_github.get_organization.side_effect = ConnectionError
-        self.assertRaises(ConnectionError, self.github_service.get_outside_collaborators_login_names)
+        self.assertRaises(
+            ConnectionError, self.github_service.get_outside_collaborators_login_names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change is a non-functional change.

The purpose is to get feedback on the layered code architecture and design choices before proceeding to refactor any functional code.

To help with rate limiting, the idea is to centralise the communication with Github via the GitHubService class, where we can better control the decorative behaviour.

I've moved authentication into the instantiation of the class, though elected not to enforce a Singleton Pattern (as described in the comments).

I've also refactored a function used in the main script to demonstrate how this new class will be used.

After this PR - the following steps will need to be completed:

- Add unit testing into CI/CD
- Refactor main scripts to use the class as a single object, with all authentication being called as a global object in the script
- Refactor methods into GithubService class with test coverage
- Add rate-limiting logic into the GithubService class (thinking via a decorator 🤔 )