### PR TITLE
🔧 Fix `AttributeError` in `get_outside_collaborators_login_names`

### DIFF
--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -14,7 +14,7 @@ class GithubService:
         logging.info("Getting Outside Collaborators Login Names")
         outside_collaborators = self.client.get_organization(
             self.organisation_name).get_outside_collaborators() or []
-        return [outside_collaborator.get("login") for outside_collaborator in outside_collaborators]
+        return [outside_collaborator.login for outside_collaborator in outside_collaborators]
 
     def close_expired_issues(self, repository_name: str):
         logging.info(f"Closing expired issues for {repository_name}")

--- a/scripts/python/services/test_GithubService.py
+++ b/scripts/python/services/test_GithubService.py
@@ -1,6 +1,8 @@
 import unittest
 from datetime import datetime, timedelta
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, MagicMock, Mock, patch
+
+from github.NamedUser import NamedUser
 
 from .GithubService import GithubService
 
@@ -22,8 +24,10 @@ class TestGithubServiceInit(unittest.TestCase):
 class TestGithubServiceGetOutsideCollaborators(unittest.TestCase):
 
     def test_returns_login_names(self, mock_github):
-        mock_github.return_value.get_organization().get_outside_collaborators.return_value = [{"login": "tom-smith"},
-                                                                                              {"login": "john.smith"}]
+        mock_github.return_value.get_organization().get_outside_collaborators.return_value = [
+            Mock(NamedUser, login="tom-smith"),
+            Mock(NamedUser, login="john.smith"),
+        ]
         response = GithubService(
             "", ORGANISATION_NAME).get_outside_collaborators_login_names()
         self.assertEqual(["tom-smith", "john.smith"], response)


### PR DESCRIPTION
[REF](https://github.com/moj-analytical-services/operations-engineering/actions/runs/4229734357/jobs/7346367923)

The `get` attribute doesn't exist on the returned object, so we're accessing the attribute directly now.

I've updated the tests to properly mock out the object under test which now catches this error 🧪 