### PR TITLE
✨ Add `RateLimiting` decorator to GithubService methods

### DIFF
--- a/scripts/python/requirements.txt
+++ b/scripts/python/requirements.txt
@@ -4,3 +4,4 @@ python-dateutil == 2.8.2
 gql
 aiohttp
 slack_sdk == 3.19.5
+freezegun==1.2.1

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -13,6 +13,18 @@ from gql.transport.aiohttp import AIOHTTPTransport
 
 def retries_github_rate_limit_exception_at_next_reset_once(func: Callable) -> Callable:
     def decorator(*args, **kwargs):
+        """
+        A decorator to retry the method when rate limiting for GitHub resets if the method fails due to RateLimitExceededException.
+
+        WARNING: Since this decorator retries methods, ensure that the method being decorated is idempotent
+         or contains only one non-idempotent method at the end of a call chain to GitHub.
+
+         Example of idempotent methods are:
+            - Retrieving data
+         Example of (potentially) non-idempotent methods are:
+            - Deleting data
+            - Updating data
+        """
         github_client_core_api = args[0].github_client_core_api
         try:
             return func(*args, **kwargs)

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -1,11 +1,31 @@
 import logging
+from calendar import timegm
 from datetime import datetime, timedelta
 from textwrap import dedent
+from time import gmtime, sleep
+from typing import Callable
 
-from github import Github
+from github import Github, RateLimitExceededException
 from github.Issue import Issue
 from gql import Client
 from gql.transport.aiohttp import AIOHTTPTransport
+
+
+def retries_github_rate_limit_exception_at_next_reset_once(func: Callable) -> Callable:
+    def decorator(*args, **kwargs):
+        github_client_core_api = args[0].github_client_core_api
+        try:
+            return func(*args, **kwargs)
+        except RateLimitExceededException:
+            logging.warning("Caught RateLimitExceededException, retrying calls when rate limit resets.")
+            core_api_reset_timestamp = github_client_core_api.get_rate_limit().core.reset
+            now_timestamp = timegm(gmtime())
+            time_until_core_api_rate_limit_resets = (
+                    core_api_reset_timestamp - now_timestamp) if core_api_reset_timestamp > now_timestamp else 0
+            sleep(time_until_core_api_rate_limit_resets)
+            return func(*args, **kwargs)
+
+    return decorator
 
 
 class GithubService:
@@ -19,12 +39,14 @@ class GithubService:
         ), fetch_schema_from_transport=False)
         self.organisation_name: str = organisation_name
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def get_outside_collaborators_login_names(self) -> list[str]:
         logging.info("Getting Outside Collaborators Login Names")
         outside_collaborators = self.github_client_core_api.get_organization(
             self.organisation_name).get_outside_collaborators() or []
         return [outside_collaborator.login for outside_collaborator in outside_collaborators]
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def close_expired_issues(self, repository_name: str) -> None:
         logging.info(f"Closing expired issues for {repository_name}")
         issues = self.github_client_core_api.get_repo(
@@ -40,6 +62,7 @@ class GithubService:
                 and issue.state == "open"
                 and grace_period < datetime.now())
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def create_an_access_removed_issue_for_user_in_repository(self, user_name: str, repository_name: str) -> None:
         logging.info(
             f"Creating an access removed issue for user {user_name} in repository {repository_name}")
@@ -61,12 +84,14 @@ class GithubService:
         """).strip("\n")
         )
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def remove_user_from_repository(self, user_name: str, repository_name: str) -> None:
         logging.info(
             f"Removing user {user_name} from repository {repository_name}")
         self.github_client_core_api.get_repo(
             f"{self.organisation_name}/{repository_name}").remove_from_collaborators(user_name)
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def get_user_permission_for_repository(self, user_name: str, repository_name: str) -> str:
         logging.info(
             f"Getting permissions for user {user_name} from repository {repository_name}")
@@ -74,18 +99,21 @@ class GithubService:
         return self.github_client_core_api.get_repo(
             f"{self.organisation_name}/{repository_name}").get_collaborator_permission(user)
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def remove_user_from_team(self, user_name: str, team_id: int) -> None:
         logging.info(f"Removing user {user_name} from team {team_id}")
         user = self.github_client_core_api.get_user(user_name)
         self.github_client_core_api.get_organization(self.organisation_name).get_team(team_id).remove_membership(
             user)
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def add_user_to_team(self, user_name: str, team_id: int) -> None:
         logging.info(f"Adding user {user_name} from team {team_id}")
         user = self.github_client_core_api.get_user(user_name)
         self.github_client_core_api.get_organization(
             self.organisation_name).get_team(team_id).add_membership(user)
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def create_new_team_with_repository(self, team_name: str, repository_name: str) -> None:
         logging.info(
             f"Creating team {team_name} for repository {repository_name}")
@@ -99,12 +127,14 @@ class GithubService:
             "Automated generated team to grant users access to this repository",
         )
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def team_exists(self, team_name) -> bool:
         logging.info(f"Checking if team {team_name} exists")
         github_teams = self.github_client_core_api.get_organization(
             self.organisation_name).get_teams() or []
         return any(github_team.name == team_name for github_team in github_teams)
 
+    @retries_github_rate_limit_exception_at_next_reset_once
     def amend_team_permissions_for_repository(self, team_id: int, permission: str, repository_name: str) -> None:
         logging.info(
             f"Amending permissions for team {team_id} in repository {repository_name}")
@@ -114,5 +144,5 @@ class GithubService:
             permission = "push"
         repo = self.github_client_core_api.get_repo(
             f"{self.organisation_name}/{repository_name}")
-        self.github_client_core_api.get_organization("moj-analytical-services").get_team(
+        self.github_client_core_api.get_organization(self.organisation_name).get_team(
             team_id).update_team_repository(repo, permission)

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -17,11 +17,12 @@ def retries_github_rate_limit_exception_at_next_reset_once(func: Callable) -> Ca
         try:
             return func(*args, **kwargs)
         except RateLimitExceededException:
-            logging.warning("Caught RateLimitExceededException, retrying calls when rate limit resets.")
+            logging.warning(
+                "Caught RateLimitExceededException, retrying calls when rate limit resets.")
             core_api_reset_timestamp = github_client_core_api.get_rate_limit().core.reset
             now_timestamp = timegm(gmtime())
             time_until_core_api_rate_limit_resets = (
-                    core_api_reset_timestamp - now_timestamp) if core_api_reset_timestamp > now_timestamp else 0
+                core_api_reset_timestamp - now_timestamp) if core_api_reset_timestamp > now_timestamp else 0
             sleep(time_until_core_api_rate_limit_resets)
             return func(*args, **kwargs)
 

--- a/scripts/python/services/test_GithubService.py
+++ b/scripts/python/services/test_GithubService.py
@@ -20,19 +20,25 @@ class TestRetriesGithubRateLimitExceptionAtNextResetOnce(unittest.TestCase):
     def test_function_is_only_called_once_with_arguments(self):
         mock_function = Mock()
         mock_github_client = Mock(Github)
-        mock_github_service = Mock(GithubService, github_client_core_api=mock_github_client)
-        retries_github_rate_limit_exception_at_next_reset_once(mock_function)(mock_github_service, "test_arg")
+        mock_github_service = Mock(
+            GithubService, github_client_core_api=mock_github_client)
+        retries_github_rate_limit_exception_at_next_reset_once(
+            mock_function)(mock_github_service, "test_arg")
         mock_function.assert_has_calls(
             [call(mock_github_service, "test_arg")])
 
     @freeze_time("2023-02-01")
     def test_function_is_called_twice_when_rate_limit_exception_raised_once(self):
-        mock_function = Mock(side_effect=[RateLimitExceededException(Mock(), Mock(), Mock()), Mock()])
+        mock_function = Mock(
+            side_effect=[RateLimitExceededException(Mock(), Mock(), Mock()), Mock()])
         mock_github_client = Mock(Github)
         mock_github_client.get_rate_limit().core.reset = timegm(gmtime())
-        mock_github_service = Mock(GithubService, github_client_core_api=mock_github_client)
-        retries_github_rate_limit_exception_at_next_reset_once(mock_function)(mock_github_service, "test_arg")
-        mock_function.assert_has_calls([call(mock_github_service, 'test_arg')], [call(mock_github_service, 'test_arg')])
+        mock_github_service = Mock(
+            GithubService, github_client_core_api=mock_github_client)
+        retries_github_rate_limit_exception_at_next_reset_once(
+            mock_function)(mock_github_service, "test_arg")
+        mock_function.assert_has_calls([call(mock_github_service, 'test_arg')], [
+                                       call(mock_github_service, 'test_arg')])
 
     @freeze_time("2023-02-01")
     def test_rate_limit_exception_raised_when_rate_limit_exception_raised_twice(self):
@@ -42,9 +48,11 @@ class TestRetriesGithubRateLimitExceptionAtNextResetOnce(unittest.TestCase):
         )
         mock_github_client = Mock(Github)
         mock_github_client.get_rate_limit().core.reset = timegm(gmtime())
-        mock_github_service = Mock(GithubService, github_client_core_api=mock_github_client)
+        mock_github_service = Mock(
+            GithubService, github_client_core_api=mock_github_client)
         self.assertRaises(RateLimitExceededException,
-                          retries_github_rate_limit_exception_at_next_reset_once(mock_function), mock_github_service,
+                          retries_github_rate_limit_exception_at_next_reset_once(
+                              mock_function), mock_github_service,
                           "test_arg")
 
 


### PR DESCRIPTION
The implementation of the RateLimiter is a reactionary simple rate limiter. The functionality only acts as a smarter retry method for our low-level operations. Thought this was reasonable as a first attempt - but comes with the downside of, at scale, potentially a bunch of APIs called at the start of the RateLimit window.

With the new decorator function, we should be careful not to decorate any functions that are not idempotent - not including the final call within the function. I've taken care to double-check check this is the case for the currently implemented functions (but another set of eyes would be good! 😄 ) and left comments on the decorator to illustrate this point.