### PR TITLE
🔧 Fix `TypeError` in `RateLimiter`

### DIFF
--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -31,7 +31,7 @@ def retries_github_rate_limit_exception_at_next_reset_once(func: Callable) -> Ca
         except RateLimitExceededException:
             logging.warning(
                 "Caught RateLimitExceededException, retrying calls when rate limit resets.")
-            core_api_reset_timestamp = github_client_core_api.get_rate_limit().core.reset
+            core_api_reset_timestamp = timegm(github_client_core_api.get_rate_limit().core.reset.timetuple())
             now_timestamp = timegm(gmtime())
             time_until_core_api_rate_limit_resets = (
                 core_api_reset_timestamp - now_timestamp) if core_api_reset_timestamp > now_timestamp else 0

--- a/scripts/python/services/GithubService.py
+++ b/scripts/python/services/GithubService.py
@@ -31,7 +31,8 @@ def retries_github_rate_limit_exception_at_next_reset_once(func: Callable) -> Ca
         except RateLimitExceededException:
             logging.warning(
                 "Caught RateLimitExceededException, retrying calls when rate limit resets.")
-            core_api_reset_timestamp = timegm(github_client_core_api.get_rate_limit().core.reset.timetuple())
+            core_api_reset_timestamp = timegm(
+                github_client_core_api.get_rate_limit().core.reset.timetuple())
             now_timestamp = timegm(gmtime())
             time_until_core_api_rate_limit_resets = (
                 core_api_reset_timestamp - now_timestamp) if core_api_reset_timestamp > now_timestamp else 0

--- a/scripts/python/services/test_GithubService.py
+++ b/scripts/python/services/test_GithubService.py
@@ -1,7 +1,5 @@
 import unittest
-from calendar import timegm
 from datetime import datetime, timedelta
-from time import gmtime
 from unittest.mock import call, MagicMock, Mock, patch
 
 from freezegun import freeze_time
@@ -32,7 +30,7 @@ class TestRetriesGithubRateLimitExceptionAtNextResetOnce(unittest.TestCase):
         mock_function = Mock(
             side_effect=[RateLimitExceededException(Mock(), Mock(), Mock()), Mock()])
         mock_github_client = Mock(Github)
-        mock_github_client.get_rate_limit().core.reset = timegm(gmtime())
+        mock_github_client.get_rate_limit().core.reset = datetime.now()
         mock_github_service = Mock(
             GithubService, github_client_core_api=mock_github_client)
         retries_github_rate_limit_exception_at_next_reset_once(
@@ -47,7 +45,7 @@ class TestRetriesGithubRateLimitExceptionAtNextResetOnce(unittest.TestCase):
             RateLimitExceededException(Mock(), Mock(), Mock())]
         )
         mock_github_client = Mock(Github)
-        mock_github_client.get_rate_limit().core.reset = timegm(gmtime())
+        mock_github_client.get_rate_limit().core.reset = datetime.now()
         mock_github_service = Mock(
             GithubService, github_client_core_api=mock_github_client)
         self.assertRaises(RateLimitExceededException,


### PR DESCRIPTION
Turns out that the PyGithub package returns a `datetime` for the `reset` property.  Whereas in the API docs, it's an epoch timestamp (int) ⌛ 

Missed this when making the tests as I was looking at the API docs 😂 

Updated the tests, which caught the error and fixed the code 🔧 

[REF](https://github.com/moj-analytical-services/operations-engineering/actions/runs/4265549574/jobs/7425003479)